### PR TITLE
.md files should map to Markdown syntax mode

### DIFF
--- a/src/hhEditor.js
+++ b/src/hhEditor.js
@@ -48,7 +48,7 @@ angular.module('hhUI', ['ui.sortable', 'firebase'])
           { name: 'XML', mode:"ace/mode/xml", ext:'.xml' },
           { name: 'YAML', mode:"ace/mode/yaml", ext:'.yaml' },
           { name: 'LUA', mode:"ace/mode/lua", ext:'.lua' },
-          { name: 'Markdown', mode:"ace/mode/ruby", ext:'.md' },
+          { name: 'Markdown', mode:"ace/mode/markdown", ext:'.md' },
           { name: 'Matlab', mode:"ace/mode/matlab", ext:'.m' },
           { name: 'Objective-C', mode:"ace/mode/objectivec", ext:'.m' },
           { name: 'PERL', mode:"ace/mode/perl", ext:'.pl' },


### PR DESCRIPTION
I think this will solve some issues I've been seeing, like some single-quote problems and other weirdness with .md files. Please let me know if I'm in error or if Ruby was being used for other reasons.
