### PR TITLE
Make the shared selection colors sane.

### DIFF
--- a/src/hhEditor.js
+++ b/src/hhEditor.js
@@ -247,7 +247,10 @@ angular.module('hhUI', ['ui.sortable', 'firebase'])
           });
         });
 
-        var firepad = Firepad.fromACE(firepadRef, editor);
+        var monokaiSelectColors = ['#421F28', '#4D3C0C', '#3D344F', '#453223'];
+        var userColor = monokaiSelectColors[Math.floor(Math.random() * monokaiSelectColors.length)];
+
+        var firepad = Firepad.fromACE(firepadRef, editor, { userColor: userColor });
 
         firepad.on('ready', function() { 
           //firepad.setText('hello world'); 


### PR DESCRIPTION
The monokai theme does not work well if the text-
background colors are very bright. It makes the
selected text very hard to read for the other user
in the same editor.

This uses darker muted versions of some monokai
colors, and assigns one at random to each user.

This could cause 2 users to have the same cursor
color, but unless there are 3+ simultaneous
editors, nobody will notice.
